### PR TITLE
Do not store the credentials in plaintext in the Jenkins storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple Jenkins plugin to redeploy Rancher2.x workload
 
 - Jenkins version >= 2.7.3
 - Rancher version >= 2.0
-- Jenkins Credentials Plugin >= 2.1.0
+- Jenkins Credentials Plugin >= 2.1.19
 
 
 
@@ -19,7 +19,7 @@ A simple Jenkins plugin to redeploy Rancher2.x workload
 
 ## Install
 
-download hpi package from release page or search this plugin in jenkins 
+download hpi package from release page or search this plugin in jenkins
 
 
 
@@ -40,7 +40,7 @@ download hpi package from release page or search this plugin in jenkins
 - login Jenkins Dashboard
 - on left navigation menu, find and click "Credentials"
 - in store list, click "Jenkins" store
-- in domain list, click "Global credentials" 
+- in domain list, click "Global credentials"
 - you will find a " Add Credentials" menu in left navigation menu. click it!
 - in Credentials page, change kind to "Rancher2.x API Keys"
 - paste **Endpoint** and **Bearer Token** you just saved in step 1

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,17 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>3.50</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>redeploy-rancher2-workload</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3.5-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.7.3</jenkins.version>
+        <jenkins.version>2.164.1</jenkins.version>
+        <java.level>8</java.level>
         <!-- Other properties you may want to use:
           ~ java.level: set to 6 if your jenkins.version <= 1.611 ~ jenkins-test-harness.version: Jenkins Test Harness version you use to test the plugin. For Jenkins version >= 1.580.1 use JTH 2.0 or higher.
           ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -102,7 +103,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.4.1</version>
+            <version>4.5.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -114,6 +115,33 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.9.10.1</version>
         </dependency>
+        <!-- org.jenkins-ci.main:jenkins-core:2.222.3 deps -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
Adding an ability to keep bearer tokens in secure ways re: jenkins guidelines.